### PR TITLE
chore: use base renovate-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,42 +3,5 @@
   "extends": [
     "local>coreruleset/renovate-config",
     "schedule:weekly"
-  ],
-  "packageRules": [
-    {
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "prBodyColumns": [
-        "Package",
-        "Type",
-        "Update",
-        "Change",
-        "Pending"
-      ]
-    },
-    {
-      "groupName": "all major dependencies",
-      "groupSlug": "all-major",
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "prBodyColumns": [
-        "Package",
-        "Type",
-        "Update",
-        "Change",
-        "Pending"
-      ]
-    }
   ]
 }


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- use base config to leverage auto-approvals
- needs https://github.com/coreruleset/renovate-config/pull/4 for major config ported to common config
