### PR TITLE
fix: release and docker warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
         env:
           METADATA: ${{ steps.build-and-push.outputs.metadata }}
         run: |
-          DIGEST=$(echo ${METADATA} | jq -r '.default."containerimage.digest"'
+          DIGEST=$(echo ${METADATA} | jq -r '.default."containerimage.digest"')
           TAGS=$(echo ${METADATA} | jq -r '.default."image.name" | tostring' | tr ',' '\n')
           images=""
           for tag in ${TAGS}; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,8 +105,8 @@ jobs:
         env:
           METADATA: ${{ steps.build-and-push.outputs.metadata }}
         run: |
-          DIGEST=$(echo ${METADATA} | jq -r '.[] | ."containerimage.digest"')
-          TAGS=$(echo ${METADATA} | jq -r '.[] | ."image.name" | tostring' | tr ',' '\n')
+          DIGEST=$(echo ${METADATA} | jq -r '.default."containerimage.digest"'
+          TAGS=$(echo ${METADATA} | jq -r '.default."image.name" | tostring' | tr ',' '\n')
           images=""
           for tag in ${TAGS}; do
             images+="${tag}@${DIGEST} "

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.1-alpine3.19@sha256:e0ea2a119ae0939a6d449ea18b2b1ba30b44986ec48dbb88f3a93371b4bf8750 as prepare
+FROM golang:1.23.1-alpine3.19@sha256:e0ea2a119ae0939a6d449ea18b2b1ba30b44986ec48dbb88f3a93371b4bf8750 AS prepare
 
 RUN apk update && apk add github-cli
 


### PR DESCRIPTION
Looks like the buildx version has some changes that impacted releasing. This PR:

- fixes warning about wrong case in Dockerfile
- updates the jq parse pattern for getting image information