### PR TITLE
feat: add support for persistent endpoint configurations

### DIFF
--- a/server/capabilities.yaml
+++ b/server/capabilities.yaml
@@ -1,0 +1,51 @@
+endpoints:
+  - path: "/*"
+    methods: [any]
+    contentType: any
+    description: |
+      Requests to any URL that is not defined as an endpoint are accepted if they are valid.
+      The response to any such request will be a status 200 without a body.
+  - path: /capabilities
+    methods: [GET]
+    contentType: "-"
+    description: | 
+      Returns a JSON document describing the capabilities of albedo, i.e., available endpoints and their functions.
+      If the query parameter 'quiet' is set to 'true', the response will only contain the path property for each
+      endpoint.
+  - path: /reflect
+    methods: [POST]
+    contentType: application/json
+    description: |
+      This endpoint responds according to the received specification.
+      The specification is a JSON document with the following fields:
+
+        status      [integer]: the status code to respond with
+        headers     [map of header definitions]: the headers to respond with
+        body        [string]: body of the response
+        encodedBody [base64-encoded string]: body of the response, base64-encoded; useful for complex payloads where escaping is difficult
+        logMessage  [string]: message to log for the request; useful for matching requests to tests
+
+      While this endpoint essentially allows for freeform responses, some restrictions apply:
+        - responses with status code 1xx don't have a body; if you specify a body together with a 1xx
+          status code, the behavior is undefined
+        - response status codes must lie in the range of [100,599]
+        - the names and values of headers must be valid according to the HTTP specification;
+          invalid headers will be dropped
+  - path: /configure_reflection
+    methods: [POST]
+    contentType: application/json
+    description: |
+      This endpoint configures other endpoints to respond as described by the received specification.
+      Any configured endpoint will behave as if it were the "/reflect" endpoint and will retain its configuration.
+      Endpoints can be overridden with new configurations.
+
+      The specification is a JSON document with the same fields as in the specification for "/reflect", with the following additions:
+
+        endpoints [list of endpoints]: endpoints to configure; an endpoint has the following fields:
+                  method                  [string]: HTTP method to match
+                  url                     [string]: URL of the endpoint, including query and fragment
+  - path: /reset
+    methods: [PUT]
+    contentType: any
+    description: |
+      Discards endpoint configurations previously created via "/configure_reflection"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -146,10 +146,12 @@ func (s *serverTestSuite) TestCapabilities() {
 	err = json.Unmarshal(body, spec)
 	s.Require().NoError(err)
 
-	s.Len(spec.Endpoints, 3)
+	s.Len(spec.Endpoints, 5)
 	s.Equal("/*", spec.Endpoints[0].Path)
 	s.Equal("/capabilities", spec.Endpoints[1].Path)
 	s.Equal("/reflect", spec.Endpoints[2].Path)
+	s.Equal("/configure_reflection", spec.Endpoints[3].Path)
+	s.Equal("/reset", spec.Endpoints[4].Path)
 
 	for _, ep := range spec.Endpoints {
 		s.NotEmpty(ep.ContentType)
@@ -179,8 +181,181 @@ func (s *serverTestSuite) TestCapabilities_Quiet() {
 	err = json.Unmarshal(body, spec)
 	s.Require().NoError(err)
 
-	s.Len(spec.Endpoints, 3)
+	s.Len(spec.Endpoints, 5)
 	s.Equal("/*", spec.Endpoints[0].Path)
 	s.Equal("/capabilities", spec.Endpoints[1].Path)
 	s.Equal("/reflect", spec.Endpoints[2].Path)
+	s.Equal("/configure_reflection", spec.Endpoints[3].Path)
+	s.Equal("/reset", spec.Endpoints[4].Path)
+}
+
+func (s *serverTestSuite) TestConfigureReflection() {
+	server := httptest.NewServer((http.HandlerFunc)(handleConfigureReflection))
+	s.T().Cleanup(server.Close)
+
+	responseBodyString := "a dummy body \t \n\r\r\n\r\n"
+	responseBody := base64.StdEncoding.EncodeToString([]byte(responseBodyString))
+	spec := &configureReflectionSpec{
+		reflectionSpec{
+			Status: 202,
+			Headers: map[string]string{
+				"header1":  "value 1",
+				"header_2": "value :2",
+			},
+			EncodedBody: responseBody,
+		},
+		[]dynamicEndpointSpec{
+			{
+				Method: "GET",
+				Url:    "/foo/bar",
+			},
+			{
+				Method: "POST",
+				Url:    "/foo/bar?some=query",
+			},
+			{
+				Method: "POST",
+				Url:    "/foo?some=query",
+			},
+		},
+	}
+	body, err := json.Marshal(spec)
+	s.Require().NoError(err)
+	request, err := http.NewRequest("POST", server.URL+"/configure_reflection", bytes.NewReader(body))
+	s.Require().NoError(err)
+	client := http.Client{}
+	_, err = client.Do(request)
+	s.Require().NoError(err)
+
+	defaultHandlingServer := httptest.NewServer((http.HandlerFunc)(handleDefault))
+	s.T().Cleanup(defaultHandlingServer.Close)
+	for _, _endpoint := range spec.Endpoints {
+		request, err = http.NewRequest(_endpoint.Method, defaultHandlingServer.URL+_endpoint.Url, bytes.NewReader(body))
+		s.Require().NoError(err)
+		response, err := client.Do(request)
+		s.Require().NoError(err)
+		s.Equal(spec.Status, response.StatusCode)
+		s.Len(response.Header, 5)
+
+		s.Contains(response.Header, "Header1")
+		s.Equal("value 1", response.Header["Header1"][0])
+		s.Contains(response.Header, "Header_2")
+		s.Equal("value :2", response.Header["Header_2"][0])
+
+		reflectedBody, err := io.ReadAll(response.Body)
+		s.Require().NoError(err)
+		s.Equal(responseBodyString, string(reflectedBody))
+	}
+}
+
+func (s *serverTestSuite) TestConfigureReflection_SameUrl() {
+	server := httptest.NewServer((http.HandlerFunc)(handleConfigureReflection))
+	s.T().Cleanup(server.Close)
+
+	responseBodyString := "a dummy body \t \n\r\r\n\r\n"
+	responseBody := base64.StdEncoding.EncodeToString([]byte(responseBodyString))
+	spec := &configureReflectionSpec{
+		reflectionSpec{
+			Status: 202,
+			Headers: map[string]string{
+				"header1":  "value 1",
+				"header_2": "value :2",
+			},
+			EncodedBody: responseBody,
+		},
+		[]dynamicEndpointSpec{
+			{
+				Method: "GET",
+				Url:    "/foo/bar",
+			},
+			{
+				Method: "OPTIONS",
+				Url:    "/foo/bar",
+			},
+		},
+	}
+	body, err := json.Marshal(spec)
+	s.Require().NoError(err)
+	request, err := http.NewRequest("POST", server.URL+"/configure_reflection", bytes.NewReader(body))
+	s.Require().NoError(err)
+	client := http.Client{}
+	_, err = client.Do(request)
+	s.Require().NoError(err)
+
+	defaultHandlingServer := httptest.NewServer((http.HandlerFunc)(handleDefault))
+	s.T().Cleanup(defaultHandlingServer.Close)
+	for _, _endpoint := range spec.Endpoints {
+		request, err = http.NewRequest(_endpoint.Method, defaultHandlingServer.URL+_endpoint.Url, bytes.NewReader(body))
+		s.Require().NoError(err)
+		response, err := client.Do(request)
+		s.Require().NoError(err)
+		s.Equal(spec.Status, response.StatusCode)
+		s.Len(response.Header, 5)
+
+		s.Contains(response.Header, "Header1")
+		s.Equal("value 1", response.Header["Header1"][0])
+		s.Contains(response.Header, "Header_2")
+		s.Equal("value :2", response.Header["Header_2"][0])
+
+		reflectedBody, err := io.ReadAll(response.Body)
+		s.Require().NoError(err)
+		s.Equal(responseBodyString, string(reflectedBody))
+	}
+}
+
+func (s *serverTestSuite) TestComputeEndPointKey() {
+	key1 := computeEndpointKey("1", "2")
+	key2 := computeEndpointKey("1", "2")
+	s.Equal(key1, key2)
+}
+
+func (s *serverTestSuite) TestReset() {
+	server := httptest.NewServer((http.HandlerFunc)(handleConfigureReflection))
+	s.T().Cleanup(server.Close)
+
+	spec := &configureReflectionSpec{
+		reflectionSpec{
+			Status:      234,
+			Headers:     map[string]string{},
+			EncodedBody: "",
+		},
+		[]dynamicEndpointSpec{
+			{
+				Method: "GET",
+				Url:    "/foo/bar",
+			},
+		},
+	}
+	body, err := json.Marshal(spec)
+	s.Require().NoError(err)
+	request, err := http.NewRequest("POST", server.URL+"/configure_reflection", bytes.NewReader(body))
+	s.Require().NoError(err)
+	client := http.Client{}
+	_, err = client.Do(request)
+	s.Require().NoError(err)
+
+	// check that the request is being reflected
+	defaultHandlingServer := httptest.NewServer((http.HandlerFunc)(handleDefault))
+	s.T().Cleanup(defaultHandlingServer.Close)
+	request, err = http.NewRequest(spec.Endpoints[0].Method, defaultHandlingServer.URL+spec.Endpoints[0].Url, bytes.NewReader(body))
+	s.Require().NoError(err)
+	response, err := client.Do(request)
+	s.Require().NoError(err)
+	s.Equal(spec.Status, response.StatusCode)
+
+	// reset
+	resetHandlingServer := httptest.NewServer((http.HandlerFunc)(handleReset))
+	s.T().Cleanup(resetHandlingServer.Close)
+	request, err = http.NewRequest("PUT", resetHandlingServer.URL+"/reset", nil)
+	s.Require().NoError(err)
+	response, err = client.Do(request)
+	s.Require().NoError(err)
+	s.Equal(200, response.StatusCode)
+
+	// check that now the default handler kicks in and no longer the configured reflection
+	request, err = http.NewRequest(spec.Endpoints[0].Method, defaultHandlingServer.URL+spec.Endpoints[0].Url, bytes.NewReader(body))
+	s.Require().NoError(err)
+	response, err = client.Do(request)
+	s.Require().NoError(err)
+	s.Equal(200, response.StatusCode)
 }

--- a/server/types.go
+++ b/server/types.go
@@ -3,3 +3,28 @@ package server
 type CapabilitiesSpec struct {
 	Endpoints []endpoint `json:"endpoints" yaml:"endpoints"`
 }
+
+type reflectionSpec struct {
+	Status      int               `json:"status"`
+	Headers     map[string]string `json:"headers"`
+	Body        string            `json:"body"`
+	EncodedBody string            `json:"encodedBody"`
+	LogMessage  string            `json:"logMessage"`
+}
+
+type configureReflectionSpec struct {
+	reflectionSpec
+	Endpoints []dynamicEndpointSpec `json:"endpoints"`
+}
+
+type dynamicEndpointSpec struct {
+	Method string `json:"method"`
+	Url    string `json:"url"`
+}
+
+type endpoint struct {
+	Path        string   `json:"path" yaml:"path"`
+	Methods     []string `json:"methods,omitempty" yaml:"methods"`
+	ContentType string   `json:"contentType,omitempty" yaml:"contentType"`
+	Description string   `json:"description,omitempty" yaml:"description"`
+}


### PR DESCRIPTION
New endpoints:
  - /configure_reflections: configure reflection as for "/reflect" for any endpoint that is not predifened
  - /reset: reset all configured reflections

Fixes #56