### PR TITLE
fix: use smaller buffer to not overflow int in `make`

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -199,8 +199,8 @@ func handleInspect(w http.ResponseWriter, r *http.Request) {
 	bodyLength := 0
 	var bodyBuffer []byte
 	if r.ContentLength == -1 {
-		// 10 MB buffer
-		bodyBuffer = make([]byte, 10*1024*1024*1024)
+		// 1 MB buffer
+		bodyBuffer = make([]byte, 1024*1024*1024)
 	} else {
 		bodyBuffer = make([]byte, r.ContentLength)
 	}


### PR DESCRIPTION
The size arguments to `make` are `int`, which may overflow (on 32-bit platforms). Use a buffer that fits into `int32`.