### PR TITLE
feat: Restructure /inspect log format

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,5 +92,6 @@ endpoints:
     methods: [any]
     contentType: any
     description: |
-      Logs debug information about the received request, such as headers and body size.
+      Logs information about the received request, such as headers and body size.
+      Body content is logged as well when debug log is enabled
 ```


### PR DESCRIPTION
- Make use of slog Attrs to structure logs for /inspect endpoint
- Optionally log body as well with `--debug`