### PR TITLE
ci: pinned moby/buildkit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
-          driver-opts: image=moby/buildkit:master
+          driver-opts: image=moby/buildkit@38cdd89aa93e60eb16fa2e39d23df3986c323403
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
-          driver-opts: image=moby/buildkit@38cdd89aa93e60eb16fa2e39d23df3986c323403
+          # renovate depName=moby/buildkit datasource=github-releases
+          driver-opts: image=moby/buildkit@8543ce4428265d547cb009e5ad62348284497a88 # v0.29.0
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0


### PR DESCRIPTION
# What?
Pinned moby/buildkit with a sha hash

# Why?

moby/buildkit previously use moby/buildkit:master, if the action compromised, will result on supply chains and compromise the repo

# Refs
- N/A